### PR TITLE
Added WallpapersRemoteAPI and response models.

### DIFF
--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -1,6 +1,8 @@
 <component name="ProjectDictionaryState">
   <dictionary name="project">
     <words>
+      <w>atleast</w>
+      <w>cccc</w>
       <w>stylepaper</w>
     </words>
   </dictionary>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/.idea/studiobot.xml
+++ b/.idea/studiobot.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="StudioBotProjectSettings">
-    <option name="shareContext" value="OptedOut" />
+    <option name="shareContext" value="OptedIn" />
   </component>
 </project>

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/WallpapersRemoteAPI.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/WallpapersRemoteAPI.kt
@@ -1,0 +1,87 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote
+
+import com.stoyanvuchev.stylepaper.BuildConfig
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response.WallpaperResponse
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response.WallpapersListingResponse
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface WallpapersRemoteAPI {
+
+    companion object {
+        val retrofitInstance: Retrofit = Retrofit.Builder()
+            .baseUrl(BuildConfig.BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+
+    @GET(BuildConfig.WALLPAPERS_LISTING_ENDPOINT)
+    suspend fun fetchLatestHomeWallpapersListing(
+        @Query("q") category: String = "",
+        @Query("sorting") sorting: String = "date_added",
+        @Query("order") order: String = "desc",
+        @Query("atleast") atLeast: String = "1080x1980",
+        @Query("ratios") ratios: String = "3x4,4x3,9x16,16x9",
+        @Query("colors") colors: String = "",
+        @Query("seed") seed: String = "",
+        @Query("page") page: Int = 1
+    ): Response<WallpapersListingResponse>
+
+    @GET(BuildConfig.WALLPAPERS_LISTING_ENDPOINT)
+    suspend fun fetchPopularHomeWallpapersListing(
+        @Query("q") category: String = "",
+        @Query("sorting") sorting: String = "views",
+        @Query("order") order: String = "desc",
+        @Query("atleast") atLeast: String = "1080x1980",
+        @Query("ratios") ratios: String = "3x4,4x3,9x16,16x9",
+        @Query("colors") colors: String = "",
+        @Query("seed") seed: String = "",
+        @Query("page") page: Int = 1
+    ): Response<WallpapersListingResponse>
+
+    @GET(BuildConfig.WALLPAPERS_LISTING_ENDPOINT)
+    suspend fun fetchRandomHomeWallpapersListing(
+        @Query("q") category: String = "",
+        @Query("sorting") sorting: String = "random",
+        @Query("order") order: String = "desc",
+        @Query("atleast") atLeast: String = "1080x1980",
+        @Query("ratios") ratios: String = "3x4,4x3,9x16,16x9",
+        @Query("colors") colors: String = "",
+        @Query("seed") seed: String = "",
+        @Query("page") page: Int = 1
+    ): Response<WallpapersListingResponse>
+
+    @GET(BuildConfig.WALLPAPERS_LISTING_ENDPOINT)
+    suspend fun fetchDiscoverWallpapersListing(
+        @Query("q") category: String = "",
+        @Query("sorting") sorting: String = "random",
+        @Query("order") order: String = "desc",
+        @Query("atleast") atLeast: String = "1080x1980",
+        @Query("ratios") ratios: String = "3x4,4x3,9x16,16x9",
+        @Query("colors") colors: String = "",
+        @Query("seed") seed: String = "",
+        @Query("page") page: Int = 1
+    ): Response<WallpapersListingResponse>
+
+    @GET(BuildConfig.SEARCH_WALLPAPERS_LISTING_ENDPOINT)
+    suspend fun searchWallpapersListing(
+        @Query("q") categoryAndQ: String = "",
+        @Query("sorting") sorting: String = "date_added",
+        @Query("order") order: String = "desc",
+        @Query("atleast") atLeast: String = "1080x1980",
+        @Query("ratios") ratios: String = "3x4,4x3,9x16,16x9",
+        @Query("colors") colors: String = "",
+        @Query("seed") seed: String = "",
+        @Query("page") page: Int = 1
+    ): Response<WallpapersListingResponse>
+
+    @GET(BuildConfig.WALLPAPER_BY_ID_ENDPOINT)
+    suspend fun fetchWallpaperById(
+        @Path("wallpaperId") wallpaperId: String
+    ): Response<WallpaperResponse>
+
+}

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpaperResponse.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpaperResponse.kt
@@ -1,0 +1,10 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response
+
+import androidx.annotation.Keep
+import com.google.gson.annotations.SerializedName
+
+@Keep
+data class WallpaperResponse(
+    @SerializedName("data")
+    val data: WallpaperResponseData
+)

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpaperResponseData.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpaperResponseData.kt
@@ -1,0 +1,76 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response
+
+import androidx.annotation.Keep
+import androidx.room.ColumnInfo
+import com.google.gson.annotations.SerializedName
+
+@Keep
+data class WallpaperResponseData(
+
+    @SerializedName("category")
+    val category: String,
+
+    @SerializedName("colors")
+    val colors: List<String>,
+
+    @ColumnInfo(name = "created_at")
+    @SerializedName("created_at")
+    val createdAt: String,
+
+    @ColumnInfo(name = "dimension_x")
+    @SerializedName("dimension_x")
+    val dimensionX: Int,
+
+    @ColumnInfo(name = "dimension_y")
+    @SerializedName("dimension_y")
+    val dimensionY: Int,
+
+    @SerializedName("favorites")
+    val favorites: Long,
+
+    @ColumnInfo(name = "file_size")
+    @SerializedName("file_size")
+    val fileSize: Long,
+
+    @ColumnInfo(name = "file_type")
+    @SerializedName("file_type")
+    val fileType: String,
+
+    @SerializedName("id")
+    val id: String,
+
+    @SerializedName("path")
+    val path: String,
+
+    @SerializedName("purity")
+    val purity: String,
+
+    @SerializedName("ratio")
+    val ratio: String,
+
+    @SerializedName("resolution")
+    val resolution: String,
+
+    @ColumnInfo(name = "short_url")
+    @SerializedName("short_url")
+    val shortUrl: String,
+
+    @SerializedName("source")
+    val source: String,
+
+    @SerializedName("tags")
+    val tags: List<WallpaperResponseTag>,
+
+    @SerializedName("thumbs")
+    val thumbs: WallpaperResponseThumbnails,
+
+    @SerializedName("uploader")
+    val uploader: WallpaperResponseUploader,
+
+    @SerializedName("url")
+    val url: String,
+
+    @SerializedName("views")
+    val views: Long
+
+)

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpaperResponseTag.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpaperResponseTag.kt
@@ -1,0 +1,33 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response
+
+import androidx.annotation.Keep
+import androidx.room.ColumnInfo
+import com.google.gson.annotations.SerializedName
+
+@Keep
+data class WallpaperResponseTag(
+
+    @SerializedName("alias")
+    val alias: String,
+
+    @SerializedName("category")
+    val category: String,
+
+    @ColumnInfo(name = "category_id")
+    @SerializedName("category_id")
+    val categoryId: Int,
+
+    @ColumnInfo(name = "created_at")
+    @SerializedName("created_at")
+    val createdAt: String,
+
+    @SerializedName("id")
+    val id: Int,
+
+    @SerializedName("name")
+    val name: String,
+
+    @SerializedName("purity")
+    val purity: String
+
+)

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpaperResponseThumbnails.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpaperResponseThumbnails.kt
@@ -1,0 +1,18 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response
+
+import androidx.annotation.Keep
+import com.google.gson.annotations.SerializedName
+
+@Keep
+data class WallpaperResponseThumbnails(
+
+    @SerializedName("large")
+    val large: String,
+
+    @SerializedName("original")
+    val original: String,
+
+    @SerializedName("small")
+    val small: String
+
+)

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpaperResponseUploader.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpaperResponseUploader.kt
@@ -1,0 +1,18 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response
+
+import androidx.annotation.Keep
+import com.google.gson.annotations.SerializedName
+
+@Keep
+data class WallpaperResponseUploader(
+
+    @SerializedName("avatar")
+    val avatar: WallpaperResponseUploaderAvatar,
+
+    @SerializedName("group")
+    val group: String,
+
+    @SerializedName("username")
+    val username: String
+
+)

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpaperResponseUploaderAvatar.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpaperResponseUploaderAvatar.kt
@@ -1,0 +1,21 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response
+
+import androidx.annotation.Keep
+import com.google.gson.annotations.SerializedName
+
+@Keep
+data class WallpaperResponseUploaderAvatar(
+
+    @SerializedName("200px")
+    val large: String,
+
+    @SerializedName("128px")
+    val medium: String,
+
+    @SerializedName("32px")
+    val small: String,
+
+    @SerializedName("20px")
+    val tiny: String
+
+)

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpapersListingResponse.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpapersListingResponse.kt
@@ -1,0 +1,12 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response
+
+import androidx.annotation.Keep
+import com.google.gson.annotations.SerializedName
+
+@Keep
+data class WallpapersListingResponse(
+    @SerializedName("data")
+    val data: List<WallpapersListingResponseItem>,
+    @SerializedName("meta")
+    val metadata: WallpapersListingResponseMetadata
+)

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpapersListingResponseItem.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpapersListingResponseItem.kt
@@ -1,0 +1,70 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response
+
+import androidx.annotation.Keep
+import androidx.room.ColumnInfo
+import com.google.gson.annotations.SerializedName
+
+@Keep
+data class WallpapersListingResponseItem(
+
+    @SerializedName("category")
+    val category: String,
+
+    @SerializedName("colors")
+    val colors: List<String>,
+
+    @ColumnInfo(name = "created_at")
+    @SerializedName("created_at")
+    val createdAt: String,
+
+    @ColumnInfo(name = "dimension_x")
+    @SerializedName("dimension_x")
+    val dimensionX: Int,
+
+    @ColumnInfo(name = "dimension_y")
+    @SerializedName("dimension_y")
+    val dimensionY: Int,
+
+    @SerializedName("favorites")
+    val favorites: Long,
+
+    @ColumnInfo(name = "file_size")
+    @SerializedName("file_size")
+    val fileSize: Long,
+
+    @ColumnInfo(name = "file_type")
+    @SerializedName("file_type")
+    val fileType: String,
+
+    @SerializedName("id")
+    val id: String,
+
+    @SerializedName("path")
+    val path: String,
+
+    @SerializedName("purity")
+    val purity: String,
+
+    @SerializedName("ratio")
+    val ratio: String,
+
+    @SerializedName("resolution")
+    val resolution: String,
+
+    @ColumnInfo(name = "short_url")
+    @SerializedName("short_url")
+    val shortUrl: String,
+
+    @SerializedName("source")
+    val source: String,
+
+    @SerializedName("thumbs")
+    val thumbnails: WallpaperResponseThumbnails,
+
+    @SerializedName("url")
+    val url: String,
+
+    @SerializedName("views")
+    val views: Long
+
+)

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpapersListingResponseMetadata.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/response/WallpapersListingResponseMetadata.kt
@@ -1,0 +1,31 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response
+
+import androidx.annotation.Keep
+import androidx.room.ColumnInfo
+import com.google.gson.annotations.SerializedName
+
+@Keep
+data class WallpapersListingResponseMetadata(
+
+    @ColumnInfo(name = "current_page")
+    @SerializedName("current_page")
+    val currentPage: Int,
+
+    @ColumnInfo(name = "last_page")
+    @SerializedName("last_page")
+    val lastPage: Int,
+
+    @ColumnInfo(name = "per_page")
+    @SerializedName("per_page")
+    val perPage: String,
+
+    @SerializedName("query")
+    val query: String? = null,
+
+    @SerializedName("seed")
+    val seed: String? = null,
+
+    @SerializedName("total")
+    val total: Int
+
+)

--- a/app/src/test/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/WallpapersRemoteAPITest.kt
+++ b/app/src/test/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/remote/WallpapersRemoteAPITest.kt
@@ -1,0 +1,103 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote
+
+import com.google.common.truth.Truth.assertThat
+import com.stoyanvuchev.stylepaper.BuildConfig
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class WallpapersRemoteAPITest {
+
+    @Test
+    fun `WallpapersRemoteAPI Retrofit instance base url matches BuildConfig's base url`() {
+
+        // Get an Retrofit instance of WallpapersRemoteAPI
+        val instance = WallpapersRemoteAPI.retrofitInstance
+
+        // Assert that WallpapersRemoteAPI base url matches BuildConfig's base url
+        assertThat(instance.baseUrl().toUrl().toString()).isEqualTo(BuildConfig.BASE_URL)
+
+    }
+
+    @Test
+    fun `WallpapersRemoteAPI Latest endpoint returns successful response`() = runTest {
+
+        // Get an instance of WallpapersRemoteAPI
+        val remoteDataSource = WallpapersRemoteAPI.retrofitInstance
+            .create(WallpapersRemoteAPI::class.java)
+
+        // Assert that the response from the endpoint is successful
+        val response = remoteDataSource.fetchLatestHomeWallpapersListing()
+        assertThat(response.isSuccessful).isTrue()
+
+    }
+
+    @Test
+    fun `WallpapersRemoteAPI Popular endpoint returns successful response`() = runTest {
+
+        // Get an instance of WallpapersRemoteAPI
+        val remoteDataSource = WallpapersRemoteAPI.retrofitInstance
+            .create(WallpapersRemoteAPI::class.java)
+
+        // Assert that the response from the endpoint is successful
+        val response = remoteDataSource.fetchPopularHomeWallpapersListing()
+        assertThat(response.isSuccessful).isTrue()
+
+    }
+
+    @Test
+    fun `WallpapersRemoteAPI Random endpoint returns successful response`() = runTest {
+
+        // Get an instance of WallpapersRemoteAPI
+        val remoteDataSource = WallpapersRemoteAPI.retrofitInstance
+            .create(WallpapersRemoteAPI::class.java)
+
+        // Assert that the response from the endpoint is successful
+        val response = remoteDataSource.fetchRandomHomeWallpapersListing()
+        assertThat(response.isSuccessful).isTrue()
+
+    }
+
+    @Test
+    fun `WallpapersRemoteAPI Discover endpoint returns successful response`() = runTest {
+
+        // Get an instance of WallpapersRemoteAPI
+        val remoteDataSource = WallpapersRemoteAPI.retrofitInstance
+            .create(WallpapersRemoteAPI::class.java)
+
+        // Assert that the response from the endpoint is successful
+        val response = remoteDataSource.fetchDiscoverWallpapersListing(colors = "66cccc")
+        assertThat(response.isSuccessful).isTrue()
+
+    }
+
+    @Test
+    fun `WallpapersRemoteAPI Search endpoint returns successful response`() = runTest {
+
+        // Get an instance of WallpapersRemoteAPI
+        val remoteDataSource = WallpapersRemoteAPI.retrofitInstance
+            .create(WallpapersRemoteAPI::class.java)
+
+        // Assert that the response from the endpoint is successful
+        val response = remoteDataSource.searchWallpapersListing(categoryAndQ = "Bliss")
+        assertThat(response.isSuccessful).isTrue()
+
+    }
+
+    @Test
+    fun `WallpapersRemoteAPI By Id endpoint returns successful response`() = runTest {
+
+        // Get an instance of WallpapersRemoteAPI
+        val remoteDataSource = WallpapersRemoteAPI.retrofitInstance
+            .create(WallpapersRemoteAPI::class.java)
+
+        // Wallpaper ID
+        val wallpaperId = "x65xed"
+
+        // Assert successful endpoint response with expected result
+        val response = remoteDataSource.fetchWallpaperById(wallpaperId)
+        val id = response.body()?.data?.id
+        assertThat(response.isSuccessful && id == wallpaperId).isTrue()
+
+    }
+
+}


### PR DESCRIPTION
This commit introduces the `WallpapersRemoteAPI` interface for fetching wallpaper data from a remote source using Retrofit.

It also adds the necessary data classes to model the API responses:
- `WallpaperResponse`
- `WallpaperResponseData`
- `WallpaperResponseTag`
- `WallpaperResponseThumbnails`
- `WallpaperResponseUploader`
- `WallpaperResponseUploaderAvatar`
- `WallpapersListingResponse`
- `WallpapersListingResponseItem`
- `WallpapersListingResponseMetadata`

Unit tests for `WallpapersRemoteAPI` have been added to verify the base URL and the successful response of each endpoint.