### PR TITLE
Added local data source for wallpapers.

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidTestResultsUserPreferences">
+    <option name="androidTestResultsTableState">
+      <map>
+        <entry key="-1768214462">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_6_Pro" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1168722102">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_6_Pro" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,6 +13,12 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
+      <SelectionState runConfigName="UIStringTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="WallpapersLocalDatabaseTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -3,6 +3,7 @@
     <words>
       <w>atleast</w>
       <w>cccc</w>
+      <w>ffcc</w>
       <w>stylepaper</w>
     </words>
   </dictionary>

--- a/app/src/androidTest/java/com/stoyanvuchev/stylepaper/core/etc/UIStringTest.kt
+++ b/app/src/androidTest/java/com/stoyanvuchev/stylepaper/core/etc/UIStringTest.kt
@@ -1,0 +1,52 @@
+package com.stoyanvuchev.stylepaper.core.etc
+
+import androidx.compose.runtime.remember
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import com.stoyanvuchev.stylepaper.test.R
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class UIStringTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun testBasicComposeString() {
+        composeRule.setContent {
+            val basicString = remember { UIString.Basic("Hello, World!") }
+            assertThat(basicString.asString()).isEqualTo("Hello, World!")
+        }
+    }
+
+    @Test
+    fun testResourceComposeString() {
+        composeRule.setContent {
+            val resourceString = remember { UIString.Resource(R.string.app_name) }
+            assertThat(resourceString.asString())
+                .isEqualTo(stringResource(R.string.app_name))
+        }
+    }
+
+    @Test
+    fun testBasicString() {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        val basicString = UIString.Basic("Hello, World!")
+        assertThat(basicString.asString(context)).isEqualTo("Hello, World!")
+    }
+
+    @Test
+    fun testResourceString() {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        val resourceString = UIString.Resource(R.string.app_name)
+        assertThat(resourceString.asString(context))
+            .isEqualTo(context.getString(R.string.app_name))
+    }
+
+}

--- a/app/src/androidTest/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/local/WallpapersLocalDatabaseTest.kt
+++ b/app/src/androidTest/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/local/WallpapersLocalDatabaseTest.kt
@@ -1,0 +1,204 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.local
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import retrofit2.HttpException
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.WallpapersRemoteAPI
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response.WallpaperResponse
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response.WallpapersListingResponse
+import com.stoyanvuchev.stylepaper.feature_wallpapers.domain.WallpapersHomeSelection
+import com.stoyanvuchev.stylepaper.feature_wallpapers.mappers.toHomeEntity
+
+@RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class WallpapersLocalDatabaseTest {
+
+    private lateinit var api: WallpapersRemoteAPI
+    private lateinit var db: WallpapersLocalDatabase
+    private lateinit var dao: WallpapersLocalDatabaseDao
+
+    private val wallpaperId = "x65xed"
+
+    @Before
+    fun setUp() {
+
+        // Initialize the Application Context required for the Database
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        // Initialize the remote API
+        api = WallpapersRemoteAPI.retrofitInstance.create(WallpapersRemoteAPI::class.java)
+
+        // Initialize the Database
+        db = Room.inMemoryDatabaseBuilder(context, WallpapersLocalDatabase::class.java).build()
+
+        // Initialize the Data Access Object (DAO)
+        dao = db.dao
+
+    }
+
+    @After
+    fun closeDb() {
+
+        // Closes the Database after completing the tests
+        db.close()
+
+    }
+
+    @Test
+    fun writeAndReadWallpapersListingResponse() = runTest(StandardTestDispatcher()) {
+
+        // Get WallpapersListingResponse from the remote API
+        val response = getWallpapersListingResponseFromAPI()
+
+        // If the Response is not NULL perform the Assertion
+        response?.let { wallpapersListingResponse ->
+
+            val fetched = System.currentTimeMillis()
+            val selection = WallpapersHomeSelection.Latest
+
+            // Map the Response to an Entity
+            val wallpapersListingResponseEntity = wallpapersListingResponse
+                .toHomeEntity(fetched = fetched, selection = selection)
+
+            // Insert the Entity
+            dao.upsertHomeWallpapersListing(wallpapersListingResponseEntity)
+
+            // Query the Entity
+            val wallpapersListingEntity = dao.getHomeWallpapersListing(selection, 1)
+
+            // Assert that the Inserted Entity is the same as the Queried Entity
+            withContext(Dispatchers.Main) {
+                assertThat(wallpapersListingEntity)
+                    .isEqualTo(wallpapersListingResponseEntity)
+            }
+
+        } ?: throw Exception()
+
+    }
+
+    @Test
+    fun writeAndReadWallpaperResponse() = runTest(StandardTestDispatcher()) {
+
+        // Get WallpaperResponse from the remote API
+        val response = getWallpaperResponseFromAPI(wallpaperId)
+
+        // If the Response is not NULL perform the Assertion
+        response?.let { wallpaperResponse ->
+
+            val wallpaperResponseEntity = wallpaperResponse
+                .toHomeEntity(System.currentTimeMillis())
+
+            // Insert the Entity
+            dao.upsertWallpaper(wallpaperResponseEntity)
+
+            // Query the Entity
+            val wallpaperEntity = dao.getWallpaperById(wallpaperId)
+
+            // Assert that the Inserted Entity is the same as the Queried Entity
+            withContext(Dispatchers.Main) {
+                assertThat(wallpaperEntity)
+                    .isEqualTo(wallpaperResponseEntity)
+            }
+
+        } ?: throw Exception()
+
+    }
+
+    @Test
+    fun writeAndDeleteWallpapersListingEntity() = runTest(StandardTestDispatcher()) {
+
+        // Try deleting an existing Wallpapers Listing Entity
+        try {
+
+            // Delete the wallpapers listing entities
+            dao.deleteHomeWallpapersListing(selection = WallpapersHomeSelection.Latest, 1)
+
+            // Attempt to get wallpapers listing entities
+            val wallpapersListingEntity = dao.getHomeWallpapersListing(
+                WallpapersHomeSelection.Latest, 1
+            )
+
+            // Assert that the wallpapers listing entities are null (nonexistent)
+            withContext(Dispatchers.Main) {
+                assertThat(wallpapersListingEntity).isEqualTo(null)
+            }
+
+        } catch (e: Exception) {
+            throw e
+        }
+
+    }
+
+    @Test
+    fun writeAndDeleteWallpaperEntity() = runTest(StandardTestDispatcher()) {
+
+        // Try deleting an existing Wallpaper Entity
+        try {
+
+            // Delete the wallpaper entity
+            dao.deleteWallpaperById(wallpaperId)
+
+            // Attempt to get wallpapers entity
+            val wallpapersEntity = dao.getWallpaperById(wallpaperId)
+
+            // Assert that the wallpaper entity is null (nonexistent)
+            withContext(Dispatchers.Main) {
+                assertThat(wallpapersEntity).isEqualTo(null)
+            }
+
+        } catch (e: Exception) {
+            throw e
+        }
+
+    }
+
+    private suspend fun getWallpapersListingResponseFromAPI(): WallpapersListingResponse? {
+
+        // Try obtaining a response from the Remote API Endpoint
+        return try {
+
+            val response = api.fetchLatestHomeWallpapersListing()
+            val data = response.body()?.data
+            val metadata = response.body()?.metadata
+
+            if (response.isSuccessful && data != null && metadata != null) {
+                WallpapersListingResponse(data = data, metadata = metadata)
+            } else throw HttpException(response)
+
+        } catch (e: Exception) {
+            throw e
+        }
+
+    }
+
+    private suspend fun getWallpaperResponseFromAPI(wallpaperId: String): WallpaperResponse? {
+
+        // Try obtaining a response from the Remote API Endpoint
+        return try {
+
+            val response = api.fetchWallpaperById(wallpaperId)
+            val data = response.body()?.data
+
+            if (response.isSuccessful && data != null) {
+                WallpaperResponse(data = data)
+            } else throw HttpException(response)
+
+        } catch (e: Exception) {
+            throw e
+        }
+
+    }
+
+}

--- a/app/src/androidTest/res/values/strings.xml
+++ b/app/src/androidTest/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Stylepaper</string>
+</resources>

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/core/etc/UIString.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/core/etc/UIString.kt
@@ -1,0 +1,30 @@
+package com.stoyanvuchev.stylepaper.core.etc
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+
+sealed interface UIString {
+
+    data class Basic(
+        val value: String
+    ) : UIString
+
+    class Resource(
+        @param:StringRes val resId: Int,
+        vararg val args: Any
+    ) : UIString
+
+    @Composable
+    fun asString(): String = when (this) {
+        is Basic -> this.value
+        is Resource -> stringResource(resId, *args)
+    }
+
+    fun asString(context: Context): String = when (this) {
+        is Basic -> this.value
+        is Resource -> context.getString(resId, *args)
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/core/ui/theme/Color.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/core/ui/theme/Color.kt
@@ -2,6 +2,17 @@ package com.stoyanvuchev.stylepaper.core.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
+val Pink = Color(0xFFEA4C88)
+val Purple = Color(0xFF663399)
+val Blue = Color(0xFF0099CC)
+val Cyan = Color(0xFF66CCCC)
+val Green = Color(0xFF77CC33)
+val Yellow = Color(0xFFFFCC33)
+val Orange = Color(0xFFFF9900)
+val Red = Color(0xFFCC3333)
+val Brown = Color(0xFF996633)
+val Grey = Color(0xFF999999)
+
 val Purple80 = Color(0xFFD0BCFF)
 val PurpleGrey80 = Color(0xFFCCC2DC)
 val Pink80 = Color(0xFFEFB8C8)

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/local/WallpapersLocalDatabase.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/local/WallpapersLocalDatabase.kt
@@ -1,0 +1,24 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.entity.WallpaperEntity
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.entity.WallpapersDiscoverListingEntity
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.entity.WallpapersHomeListingEntity
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.entity.WallpapersSearchListingEntity
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.type_converters.WallpapersLocalDatabaseTypeConverters
+
+@Database(
+    entities = [
+        WallpapersHomeListingEntity::class,
+        WallpapersDiscoverListingEntity::class,
+        WallpapersSearchListingEntity::class,
+        WallpaperEntity::class
+    ],
+    version = 1
+)
+@TypeConverters(WallpapersLocalDatabaseTypeConverters::class)
+abstract class WallpapersLocalDatabase : RoomDatabase() {
+    abstract val dao: WallpapersLocalDatabaseDao
+}

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/local/WallpapersLocalDatabaseDao.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/local/WallpapersLocalDatabaseDao.kt
@@ -1,0 +1,130 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.entity.WallpaperEntity
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.entity.WallpapersDiscoverListingEntity
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.entity.WallpapersHomeListingEntity
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.entity.WallpapersSearchListingEntity
+import com.stoyanvuchev.stylepaper.feature_wallpapers.domain.WallpapersCategory
+import com.stoyanvuchev.stylepaper.feature_wallpapers.domain.WallpapersHomeSelection
+
+@Dao
+interface WallpapersLocalDatabaseDao {
+
+    // Home Wallpapers Listing Entities
+
+    @Insert(
+        onConflict = OnConflictStrategy.REPLACE,
+        entity = WallpapersHomeListingEntity::class
+    )
+    suspend fun upsertHomeWallpapersListing(
+        wallpapersHomeListingEntity: WallpapersHomeListingEntity
+    )
+
+    @Query(
+        "SELECT * FROM wallpapers_home_table " +
+                "WHERE selection = :selection " +
+                "AND current_page = :page"
+    )
+    suspend fun getHomeWallpapersListing(
+        selection: WallpapersHomeSelection,
+        page: Int
+    ): WallpapersHomeListingEntity?
+
+    @Query(
+        "DELETE FROM wallpapers_home_table " +
+                "WHERE selection = :selection " +
+                "AND current_page = :page"
+    )
+    suspend fun deleteHomeWallpapersListing(
+        selection: WallpapersHomeSelection,
+        page: Int
+    )
+
+    // Discover Wallpapers Listing Entities
+
+    @Insert(
+        onConflict = OnConflictStrategy.REPLACE,
+        entity = WallpapersDiscoverListingEntity::class
+    )
+    suspend fun upsertDiscoverWallpapersListing(
+        wallpapersDiscoverListingEntity: WallpapersDiscoverListingEntity
+    )
+
+    @Query(
+        "SELECT * FROM wallpapers_discover_table " +
+                "WHERE category = :category " +
+                "AND color = :color " +
+                "AND current_page = :page"
+    )
+    suspend fun getDiscoverWallpapersListing(
+        category: WallpapersCategory,
+        color: String,
+        page: Int
+    ): WallpapersDiscoverListingEntity?
+
+    @Query(
+        "DELETE FROM wallpapers_discover_table " +
+                "WHERE category = :category " +
+                "AND color = :color " +
+                "AND current_page = :page"
+    )
+    suspend fun deleteDiscoverWallpapersListing(
+        category: WallpapersCategory,
+        color: String,
+        page: Int
+    )
+
+    // Search Wallpapers Listing Entities
+
+    @Insert(
+        onConflict = OnConflictStrategy.REPLACE,
+        entity = WallpapersSearchListingEntity::class
+    )
+    suspend fun upsertSearchWallpapersListing(
+        wallpapersSearchListingEntity: WallpapersSearchListingEntity
+    )
+
+    @Query(
+        "SELECT * FROM wallpapers_search_table " +
+                "WHERE search_query = :searchQuery " +
+                "AND category = :category " +
+                "AND color = :color " +
+                "AND current_page = :page"
+    )
+    suspend fun getSearchWallpapersListing(
+        searchQuery: String,
+        category: WallpapersCategory,
+        color: String,
+        page: Int
+    ): WallpapersSearchListingEntity?
+
+    @Query(
+        "DELETE FROM wallpapers_search_table " +
+                "WHERE search_query = :searchQuery " +
+                "AND category = :category " +
+                "AND color = :color " +
+                "AND current_page = :page"
+    )
+    suspend fun deleteSearchWallpapersListing(
+        searchQuery: String,
+        category: WallpapersCategory,
+        color: String,
+        page: Int
+    )
+
+    // Wallpaper Entity
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertWallpaper(wallpaperEntity: WallpaperEntity)
+
+    @Query("SELECT * FROM WallpaperEntity WHERE id = :id")
+    suspend fun getWallpaperById(id: String): WallpaperEntity?
+
+    @Query("DELETE FROM WallpaperEntity WHERE id = :id")
+    suspend fun deleteWallpaperById(id: String)
+
+}

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/local/entity/WallpaperEntity.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/local/entity/WallpaperEntity.kt
@@ -1,0 +1,52 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response.WallpaperResponseTag
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response.WallpaperResponseThumbnails
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response.WallpaperResponseUploader
+
+@Entity
+data class WallpaperEntity(
+
+    @PrimaryKey
+    val id: String,
+
+    val fetched: Long,
+    val category: String,
+    val colors: List<String>,
+
+    @ColumnInfo(name = "created_at")
+    val createdAt: String,
+
+    @ColumnInfo(name = "dimension_x")
+    val dimensionX: Int,
+
+    @ColumnInfo(name = "dimension_y")
+    val dimensionY: Int,
+
+    val favorites: Long,
+
+    @ColumnInfo(name = "file_size")
+    val fileSize: Long,
+
+    @ColumnInfo(name = "file_type")
+    val fileType: String,
+
+    val path: String,
+    val purity: String,
+    val ratio: String,
+    val resolution: String,
+
+    @ColumnInfo(name = "short_url")
+    val shortUrl: String,
+
+    val source: String,
+    val tags: List<WallpaperResponseTag>,
+    val thumbs: WallpaperResponseThumbnails,
+    val uploader: WallpaperResponseUploader,
+    val url: String,
+    val views: Long
+
+)

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/local/entity/WallpapersDiscoverListingEntity.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/local/entity/WallpapersDiscoverListingEntity.kt
@@ -1,0 +1,31 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response.WallpapersListingResponseItem
+import com.stoyanvuchev.stylepaper.feature_wallpapers.domain.WallpapersCategory
+
+@Entity(
+    tableName = "wallpapers_discover_table",
+    primaryKeys = ["category", "color", "current_page"]
+)
+data class WallpapersDiscoverListingEntity(
+
+    val fetched: Long,
+    val category: WallpapersCategory,
+    val color: String,
+    val wallpapers: List<WallpapersListingResponseItem>,
+
+    @ColumnInfo(name = "current_page")
+    val currentPage: Int,
+
+    @ColumnInfo(name = "last_page")
+    val lastPage: Int,
+
+    @ColumnInfo(name = "per_page")
+    val perPage: String,
+
+    val seed: String,
+    val total: Int
+
+)

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/local/entity/WallpapersHomeListingEntity.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/local/entity/WallpapersHomeListingEntity.kt
@@ -1,0 +1,30 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response.WallpapersListingResponseItem
+import com.stoyanvuchev.stylepaper.feature_wallpapers.domain.WallpapersHomeSelection
+
+@Entity(
+    tableName = "wallpapers_home_table",
+    primaryKeys = ["selection", "current_page"]
+)
+data class WallpapersHomeListingEntity(
+
+    val fetched: Long,
+    val selection: WallpapersHomeSelection,
+    val wallpapers: List<WallpapersListingResponseItem>,
+
+    @ColumnInfo(name = "current_page")
+    val currentPage: Int,
+
+    @ColumnInfo(name = "last_page")
+    val lastPage: Int,
+
+    @ColumnInfo(name = "per_page")
+    val perPage: String,
+
+    val seed: String,
+    val total: Int
+
+)

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/local/entity/WallpapersSearchListingEntity.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/local/entity/WallpapersSearchListingEntity.kt
@@ -1,0 +1,35 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response.WallpapersListingResponseItem
+import com.stoyanvuchev.stylepaper.feature_wallpapers.domain.WallpapersCategory
+
+@Entity(
+    tableName = "wallpapers_search_table",
+    primaryKeys = ["search_query", "category", "color", "current_page"]
+)
+data class WallpapersSearchListingEntity(
+
+    val fetched: Long,
+
+    @ColumnInfo(name = "search_query")
+    val searchQuery: String,
+
+    val category: WallpapersCategory,
+    val color: String,
+    val wallpapers: List<WallpapersListingResponseItem>,
+
+    @ColumnInfo(name = "current_page")
+    val currentPage: Int,
+
+    @ColumnInfo(name = "last_page")
+    val lastPage: Int,
+
+    @ColumnInfo(name = "per_page")
+    val perPage: String,
+
+    val seed: String,
+    val total: Int
+
+)

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/local/type_converters/WallpapersLocalDatabaseTypeConverters.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/data/local/type_converters/WallpapersLocalDatabaseTypeConverters.kt
@@ -1,0 +1,169 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.type_converters
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.stoyanvuchev.stylepaper.core.etc.UIString
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response.WallpaperResponseTag
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response.WallpaperResponseThumbnails
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response.WallpaperResponseUploader
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response.WallpaperResponseUploaderAvatar
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response.WallpapersListingResponseItem
+import com.stoyanvuchev.stylepaper.feature_wallpapers.domain.WallpapersCategory
+import com.stoyanvuchev.stylepaper.feature_wallpapers.domain.WallpapersHomeSelection
+
+/**
+ *
+ * Since Room only operates with Primitive data types (String, Integer, Boolean etc.)
+ * it is required to convert Non-primitive data objects to JSON strings.
+ *
+ * */
+
+class WallpapersLocalDatabaseTypeConverters {
+
+    @TypeConverter
+    fun fromJsonToWallpaperResponseUploaderAvatar(
+        value: String?
+    ): WallpaperResponseUploaderAvatar? {
+        val type = object : TypeToken<WallpaperResponseUploaderAvatar>() {}.type
+        return Gson().fromJson(value, type)
+    }
+
+    @TypeConverter
+    fun fromWallpaperResponseUploaderAvatarToJson(
+        value: WallpaperResponseUploaderAvatar?
+    ): String? {
+        val type = object : TypeToken<WallpaperResponseUploaderAvatar>() {}.type
+        return Gson().toJson(value, type)
+    }
+
+    @TypeConverter
+    fun fromJsonToWallpapersListingResponseItemList(
+        value: String?
+    ): List<WallpapersListingResponseItem>? {
+        val type = object : TypeToken<List<WallpapersListingResponseItem>>() {}.type
+        return Gson().fromJson(value, type)
+    }
+
+    @TypeConverter
+    fun fromWallpapersListingResponseItemListToJson(
+        value: List<WallpapersListingResponseItem>?
+    ): String? {
+        val type = object : TypeToken<List<WallpapersListingResponseItem>>() {}.type
+        return Gson().toJson(value, type)
+    }
+
+    @TypeConverter
+    fun fromJsonToWallpapersHomeSelection(
+        value: String?
+    ): WallpapersHomeSelection? {
+        val type = object : TypeToken<WallpapersHomeSelection>() {}.type
+        return Gson().fromJson(value, type)
+    }
+
+    @TypeConverter
+    fun fromWallpapersHomeSelectionToJson(
+        value: WallpapersHomeSelection?
+    ): String? {
+        val type = object : TypeToken<WallpapersHomeSelection>() {}.type
+        return Gson().toJson(value, type)
+    }
+
+
+    @TypeConverter
+    fun fromJsonToWallpapersCategory(
+        value: String?
+    ): WallpapersCategory? {
+        val type = object : TypeToken<WallpapersCategory>() {}.type
+        return Gson().fromJson(value, type)
+    }
+
+    @TypeConverter
+    fun fromWallpapersCategoryToJson(
+        value: WallpapersCategory?
+    ): String? {
+        val type = object : TypeToken<WallpapersCategory>() {}.type
+        return Gson().toJson(value, type)
+    }
+
+    @TypeConverter
+    fun fromJsonToWallpaperResponseThumbnails(
+        value: String?
+    ): WallpaperResponseThumbnails? {
+        val type = object : TypeToken<WallpaperResponseThumbnails>() {}.type
+        return Gson().fromJson(value, type)
+    }
+
+    @TypeConverter
+    fun fromWallpaperResponseThumbnailsToJson(
+        value: WallpaperResponseThumbnails?
+    ): String? {
+        val type = object : TypeToken<WallpaperResponseThumbnails>() {}.type
+        return Gson().toJson(value, type)
+    }
+
+    @TypeConverter
+    fun fromJsonToWallpaperResponseTagList(
+        value: String?
+    ): List<WallpaperResponseTag>? {
+        val type = object : TypeToken<List<WallpaperResponseTag>>() {}.type
+        return Gson().fromJson(value, type)
+    }
+
+    @TypeConverter
+    fun fromWallpaperResponseTagListToJson(
+        value: List<WallpaperResponseTag>?
+    ): String? {
+        val type = object : TypeToken<List<WallpaperResponseTag>>() {}.type
+        return Gson().toJson(value, type)
+    }
+
+    @TypeConverter
+    fun fromJsonToWallpaperResponseUploader(
+        value: String?
+    ): WallpaperResponseUploader? {
+        val type = object : TypeToken<WallpaperResponseUploader>() {}.type
+        return Gson().fromJson(value, type)
+    }
+
+    @TypeConverter
+    fun fromWallpaperResponseUploaderToJson(
+        value: WallpaperResponseUploader?
+    ): String? {
+        val type = object : TypeToken<WallpaperResponseUploader>() {}.type
+        return Gson().toJson(value, type)
+    }
+
+    @TypeConverter
+    fun fromJsonToColorsList(
+        value: String?
+    ): List<String>? {
+        val type = object : TypeToken<List<String>>() {}.type
+        return Gson().fromJson(value, type)
+    }
+
+    @TypeConverter
+    fun fromColorsListToJson(
+        value: List<String>?
+    ): String? {
+        val type = object : TypeToken<List<String>>() {}.type
+        return Gson().toJson(value, type)
+    }
+
+    @TypeConverter
+    fun fromJsonToUIString(
+        value: String?
+    ): UIString? {
+        val type = object : TypeToken<UIString>() {}.type
+        return Gson().fromJson(value, type)
+    }
+
+    @TypeConverter
+    fun fromUIStringToJson(
+        value: UIString?
+    ): String? {
+        val type = object : TypeToken<UIString>() {}.type
+        return Gson().toJson(value, type)
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/domain/WallpaperColor.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/domain/WallpaperColor.kt
@@ -1,0 +1,82 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.domain
+
+import androidx.compose.ui.graphics.Color
+import com.stoyanvuchev.stylepaper.core.ui.theme.Blue
+import com.stoyanvuchev.stylepaper.core.ui.theme.Brown
+import com.stoyanvuchev.stylepaper.core.ui.theme.Cyan
+import com.stoyanvuchev.stylepaper.core.ui.theme.Green
+import com.stoyanvuchev.stylepaper.core.ui.theme.Grey
+import com.stoyanvuchev.stylepaper.core.ui.theme.Orange
+import com.stoyanvuchev.stylepaper.core.ui.theme.Pink
+import com.stoyanvuchev.stylepaper.core.ui.theme.Purple
+import com.stoyanvuchev.stylepaper.core.ui.theme.Red
+import com.stoyanvuchev.stylepaper.core.ui.theme.Yellow
+
+sealed class WallpaperColor(
+    val uiColor: Color,
+    val hexColor: String
+) {
+
+    companion object Companion {
+        val colorsList = listOf(
+            None, PinkColor, PurpleColor, BlueColor, CyanColor, GreenColor,
+            YellowColor, OrangeColor, RedColor, BrownColor, GreyColor
+        )
+    }
+
+    object None : WallpaperColor(
+        uiColor = Color(0x00000000),
+        hexColor = ""
+    )
+
+    object PinkColor : WallpaperColor(
+        uiColor = Pink,
+        hexColor = "ea4c88"
+    )
+
+    object PurpleColor : WallpaperColor(
+        uiColor = Purple,
+        hexColor = "663399"
+    )
+
+    object BlueColor : WallpaperColor(
+        uiColor = Blue,
+        hexColor = "0099CC"
+    )
+
+    object CyanColor : WallpaperColor(
+        uiColor = Cyan,
+        hexColor = "66CCCC"
+    )
+
+    object GreenColor : WallpaperColor(
+        uiColor = Green,
+        hexColor = "77CC33"
+    )
+
+    object YellowColor : WallpaperColor(
+        uiColor = Yellow,
+        hexColor = "ffcc33"
+    )
+
+    object OrangeColor : WallpaperColor(
+        uiColor = Orange,
+        hexColor = "ff9900"
+    )
+
+    object RedColor : WallpaperColor(
+        uiColor = Red,
+        hexColor = "cc3333"
+    )
+
+    object BrownColor : WallpaperColor(
+        uiColor = Brown,
+        hexColor = "996633"
+    )
+
+    object GreyColor : WallpaperColor(
+        uiColor = Grey,
+        hexColor = "999999"
+    )
+
+}

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/domain/WallpapersCategory.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/domain/WallpapersCategory.kt
@@ -1,0 +1,23 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.domain
+
+sealed class WallpapersCategory(val value: String) {
+
+    companion object {
+
+        val wallpaperCategories = listOf(
+            None, Abstract, Nature, Animals, Gradient,
+            Cityscape, Patterns, Anime
+        )
+
+    }
+
+    data object None : WallpapersCategory("")
+    data object Abstract : WallpapersCategory("abstract")
+    data object Nature : WallpapersCategory("nature")
+    data object Animals : WallpapersCategory("animals")
+    data object Gradient : WallpapersCategory("gradient")
+    data object Cityscape : WallpapersCategory("cityscape")
+    data object Patterns : WallpapersCategory("patterns")
+    data object Anime : WallpapersCategory("anime")
+
+}

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/domain/WallpapersHomeSelection.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/domain/WallpapersHomeSelection.kt
@@ -1,0 +1,45 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.domain
+
+import com.stoyanvuchev.stylepaper.R
+import com.stoyanvuchev.stylepaper.core.etc.UIString
+
+enum class WallpapersHomeSelection {
+
+    Latest {
+
+        override val label: UIString
+            get() = UIString.Resource(R.string.latest_wallpapers_selection)
+
+        override val contentDescription: UIString
+            get() = UIString.Resource(R.string.latest_wallpapers)
+
+    },
+
+    Popular {
+
+        override val label: UIString
+            get() = UIString.Resource(R.string.popular_wallpapers_selection)
+
+        override val contentDescription: UIString
+            get() = UIString.Resource(R.string.popular_wallpapers)
+
+    },
+
+    Random {
+
+        override val label: UIString
+            get() = UIString.Resource(R.string.random_wallpapers_selection)
+
+        override val contentDescription: UIString
+            get() = UIString.Resource(R.string.random_wallpapers)
+
+    };
+
+    companion object {
+        val homeScreenSelections by lazy { listOf(Latest, Popular, Random) }
+    }
+
+    abstract val label: UIString
+    abstract val contentDescription: UIString
+
+}

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/mappers/WallpaperResponseToEntityMappers.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/mappers/WallpaperResponseToEntityMappers.kt
@@ -1,0 +1,83 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.mappers
+
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.entity.WallpaperEntity
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.entity.WallpapersDiscoverListingEntity
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.entity.WallpapersHomeListingEntity
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.local.entity.WallpapersSearchListingEntity
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response.WallpaperResponse
+import com.stoyanvuchev.stylepaper.feature_wallpapers.data.remote.response.WallpapersListingResponse
+import com.stoyanvuchev.stylepaper.feature_wallpapers.domain.WallpapersCategory
+import com.stoyanvuchev.stylepaper.feature_wallpapers.domain.WallpapersHomeSelection
+import kotlin.collections.distinct
+
+fun WallpapersListingResponse.toHomeEntity(
+    fetched: Long,
+    selection: WallpapersHomeSelection
+) = WallpapersHomeListingEntity(
+    fetched = fetched,
+    selection = selection,
+    wallpapers = data.distinct(),
+    currentPage = metadata.currentPage,
+    lastPage = metadata.lastPage,
+    perPage = metadata.perPage,
+    seed = metadata.seed ?: "",
+    total = metadata.total
+)
+
+fun WallpapersListingResponse.toDiscoverEntity(
+    fetched: Long,
+    category: WallpapersCategory,
+    color: String
+) = WallpapersDiscoverListingEntity(
+    fetched = fetched,
+    category = category,
+    color = color,
+    wallpapers = data.distinct(),
+    currentPage = metadata.currentPage,
+    lastPage = metadata.lastPage,
+    perPage = metadata.perPage,
+    seed = metadata.seed ?: "",
+    total = metadata.total
+)
+
+fun WallpapersListingResponse.toSearchEntity(
+    fetched: Long,
+    searchQuery: String,
+    category: WallpapersCategory,
+    color: String
+) = WallpapersSearchListingEntity(
+    fetched = fetched,
+    searchQuery = searchQuery,
+    category = category,
+    color = color,
+    wallpapers = data.distinct(),
+    currentPage = metadata.currentPage,
+    lastPage = metadata.lastPage,
+    perPage = metadata.perPage,
+    seed = metadata.seed ?: "",
+    total = metadata.total
+)
+
+fun WallpaperResponse.toHomeEntity(fetched: Long) = WallpaperEntity(
+    id = data.id,
+    fetched = fetched,
+    category = data.category,
+    colors = data.colors,
+    createdAt = data.createdAt,
+    dimensionX = data.dimensionX,
+    dimensionY = data.dimensionY,
+    favorites = data.favorites,
+    fileSize = data.fileSize,
+    fileType = data.fileType,
+    path = data.path,
+    purity = data.purity,
+    ratio = data.ratio,
+    resolution = data.resolution,
+    shortUrl = data.shortUrl,
+    source = data.source,
+    tags = data.tags,
+    thumbs = data.thumbs,
+    uploader = data.uploader,
+    url = data.url,
+    views = data.views
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,9 @@
 <resources>
     <string name="app_name">Stylepaper</string>
+    <string name="latest_wallpapers_selection">Latest</string>
+    <string name="latest_wallpapers">Latest wallpapers</string>
+    <string name="popular_wallpapers_selection">Popular</string>
+    <string name="popular_wallpapers">Popular wallpapers</string>
+    <string name="random_wallpapers_selection">Random</string>
+    <string name="random_wallpapers">Random wallpapers</string>
 </resources>


### PR DESCRIPTION
This commit introduces the local data source for wallpapers using Room persistence library. It includes:
- `WallpaperEntity`, `WallpapersHomeListingEntity`, `WallpapersDiscoverListingEntity`, and `WallpapersSearchListingEntity` as data entities.
- `WallpapersLocalDatabase` as the Room database.
- `WallpapersLocalDatabaseDao` for data access operations.
- `WallpapersLocalDatabaseTypeConverters` to handle custom data types.
- Mappers to convert remote responses to local entities.
- Domain models for `WallpaperColor`, `WallpapersCategory`, and `WallpapersHomeSelection`.
- `UIString` sealed interface for handling string resources in a type-safe manner.
- Unit tests for `UIString` and `WallpapersLocalDatabase`.
- Added new string resources for wallpaper selections.
- Updated color definitions.