### PR TITLE
Added AppNavigationBar and integrated it into AppNavHost.

### DIFF
--- a/app/src/main/java/com/stoyanvuchev/stylepaper/AppNavHost.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/AppNavHost.kt
@@ -1,6 +1,10 @@
 package com.stoyanvuchev.stylepaper
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import com.stoyanvuchev.stylepaper.core.ui.navhost.NavHostTransitions
@@ -20,14 +24,24 @@ fun AppNavHost(
         NavHostTransitions.Exit.scaleAndFadeOutWithOvershoot()
     }
 
-    NavHost(
-        navController = navController,
-        startDestination = Screen.WallpapersNavigation,
-        enterTransition = { defaultEnterTransition },
-        exitTransition = { defaultExitTransition }
-    ) {
+    Box(modifier = Modifier.fillMaxSize()) {
 
-        wallpapersNavGraph(
+        NavHost(
+            modifier = Modifier.fillMaxSize(),
+            navController = navController,
+            startDestination = Screen.WallpapersNavigation,
+            enterTransition = { defaultEnterTransition },
+            exitTransition = { defaultExitTransition }
+        ) {
+
+            wallpapersNavGraph(
+                navController = navController
+            )
+
+        }
+
+        AppNavigationBar(
+            modifier = Modifier.align(Alignment.BottomCenter),
             navController = navController
         )
 

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/AppNavigationBar.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/AppNavigationBar.kt
@@ -1,0 +1,103 @@
+package com.stoyanvuchev.stylepaper
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import com.stoyanvuchev.stylepaper.feature_wallpapers.presentation.Screen
+import com.stoyanvuchev.stylepaper.feature_wallpapers.presentation.wallpapersNavBarDestinations
+
+@Composable
+fun AppNavigationBar(
+    modifier: Modifier = Modifier,
+    navController: NavHostController
+) {
+
+    val destinations = rememberSaveable { wallpapersNavBarDestinations }
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination by rememberUpdatedState(
+        navBackStackEntry?.destination
+    )
+
+    val isNavBarVisible by remember(currentDestination) {
+        derivedStateOf {
+            destinations.any { destination ->
+                currentDestination?.hasRoute(destination::class) ?: false
+            }
+        }
+    }
+
+    AnimatedVisibility(
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(modifier),
+        visible = isNavBarVisible,
+        enter = remember { fadeIn() + slideInVertically { it } },
+        exit = remember { slideOutVertically { it } + fadeOut() }
+    ) {
+
+        NavigationBar(modifier = Modifier.fillMaxWidth()) {
+
+            destinations.forEach { screen ->
+
+                val selected by remember(currentDestination) {
+                    derivedStateOf {
+                        currentDestination?.hasRoute(screen::class) ?: false
+                    }
+                }
+
+                NavigationBarItem(
+                    label = { Text(text = stringResource(id = screen.label)) },
+                    icon = {
+
+                        Icon(
+                            painter = painterResource(id = screen.icon),
+                            contentDescription = stringResource(id = screen.description),
+                        )
+
+                    },
+                    selected = selected,
+                    onClick = remember {
+                        {
+
+                            navController.navigate(screen) {
+
+                                popUpTo(Screen.Home) {
+                                    this.saveState = true
+                                    this.inclusive = false
+                                }
+
+                                launchSingleTop = true
+                                restoreState = true
+
+                            }
+
+                        }
+                    }
+                )
+
+            }
+
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/presentation/Screen.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/presentation/Screen.kt
@@ -2,13 +2,12 @@ package com.stoyanvuchev.stylepaper.feature_wallpapers.presentation
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.compose.runtime.Immutable
 import com.stoyanvuchev.stylepaper.R
 import com.stoyanvuchev.stylepaper.core.ui.navhost.NavScreen
-import com.stoyanvuchev.stylepaper.feature_wallpapers.presentation.Screen.Discover
-import com.stoyanvuchev.stylepaper.feature_wallpapers.presentation.Screen.Home
-import com.stoyanvuchev.stylepaper.feature_wallpapers.presentation.Screen.Menu
 import kotlinx.serialization.Serializable
 
+@Immutable
 @Serializable
 sealed class Screen(
     @param:DrawableRes val icon: Int,
@@ -67,4 +66,8 @@ sealed class Screen(
 
 }
 
-val navDestinations: List<Screen> by lazy { listOf(Home, Discover, Menu) }
+val wallpapersNavBarDestinations = listOf(
+    Screen.Home,
+    Screen.Discover,
+    Screen.Menu
+)

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/presentation/home/components/WallpapersHomeScreenContainer.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/presentation/home/components/WallpapersHomeScreenContainer.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp


### PR DESCRIPTION
This commit introduces the `AppNavigationBar` composable, which provides navigation between the main screens of the wallpapers feature.

Key changes include:
- Creation of `AppNavigationBar.kt` with the `AppNavigationBar` composable.
- Integration of `AppNavigationBar` into `AppNavHost.kt`, displaying it at the bottom of the screen.
- Updated `Screen.kt` to define `wallpapersNavBarDestinations` and make `Screen` immutable.
- Minor adjustment in `WallpapersHomeScreenContainer.kt` (removed an alpha modifier).