### PR TITLE
Implemented "Set wallpaper" functionality.

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-09-16T15:46:45.956363Z">
+        <DropdownSelection timestamp="2025-09-16T19:06:41.023440Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/stoyan/.android/avd/Pixel_6_Pro.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/stoyan/.android/avd/Pixel_7_Pro.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,19 @@
             android:exported="false"
             android:foregroundServiceType="dataSync" />
 
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+
+        </provider>
+
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/framework/utils/FileUtils.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/framework/utils/FileUtils.kt
@@ -9,7 +9,17 @@ fun isWallpaperDownloaded(
     context: Context,
     id: String,
     fileType: String
-): Boolean {
+): Boolean = getWallpaperFile(
+    context = context,
+    id = id,
+    fileType = fileType
+).exists()
+
+fun getWallpaperFile(
+    context: Context,
+    id: String,
+    fileType: String
+): File {
 
     val fileName = getFileName(id, fileType)
     val dir = File(
@@ -17,8 +27,6 @@ fun isWallpaperDownloaded(
         "Stylepaper"
     )
 
-    val file = File(dir, fileName)
+    return File(dir, fileName)
 
-    println("AJA: type: $fileType, Name: $fileName, Path: ${file.absolutePath}")
-    return file.exists()
 }

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/framework/utils/WallpaperManagerUtils.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/framework/utils/WallpaperManagerUtils.kt
@@ -1,0 +1,36 @@
+package com.stoyanvuchev.stylepaper.feature_wallpapers.framework.utils
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import com.stoyanvuchev.stylepaper.R
+
+fun setWallpaperWithChooser(
+    context: Context,
+    id: String,
+    fileType: String
+) {
+
+    val file = getWallpaperFile(context, id, fileType)
+    if (!file.exists()) return
+
+    val uri = FileProvider.getUriForFile(
+        context,
+        "${context.packageName}.provider",
+        file
+    )
+
+    val intent = Intent(Intent.ACTION_ATTACH_DATA).apply {
+        setDataAndType(uri, "image/*")
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        putExtra("mimeType", "image/*")
+    }
+
+    context.startActivity(
+        Intent.createChooser(
+            intent,
+            context.getString(R.string.set_as)
+        )
+    )
+
+}

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/presentation/wallpaper_details/WallpaperDetailsScreenViewModel.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/presentation/wallpaper_details/WallpaperDetailsScreenViewModel.kt
@@ -104,7 +104,7 @@ class WallpaperDetailsScreenViewModel @Inject constructor(
             is Fullscreen -> sendActionEvent(action)
             is ScrollToTop -> sendActionEvent(action)
             is Download -> sendActionEvent(action)
-            is Apply -> showSnackbar(UIString.Resource(R.string.not_implemented))
+            is Apply -> sendActionEvent(action)
             is Save -> showSnackbar(UIString.Resource(R.string.not_implemented))
         }
     }

--- a/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/presentation/wallpaper_details/ui_components/WallpaperDetailsScreen.kt
+++ b/app/src/main/java/com/stoyanvuchev/stylepaper/feature_wallpapers/presentation/wallpaper_details/ui_components/WallpaperDetailsScreen.kt
@@ -33,6 +33,7 @@ import com.stoyanvuchev.stylepaper.core.ui.components.SnackbarHostAndScrollButto
 import com.stoyanvuchev.stylepaper.core.ui.event.NavigationEvent
 import com.stoyanvuchev.stylepaper.core.ui.event.SnackbarEvent
 import com.stoyanvuchev.stylepaper.feature_wallpapers.framework.service.WallpaperDownloadService
+import com.stoyanvuchev.stylepaper.feature_wallpapers.framework.utils.setWallpaperWithChooser
 import com.stoyanvuchev.stylepaper.feature_wallpapers.presentation.wallpaper_details.WallpaperDetailsScreenUIAction
 import com.stoyanvuchev.stylepaper.feature_wallpapers.presentation.wallpaper_details.WallpaperDetailsScreenViewModel
 import kotlinx.coroutines.delay
@@ -116,7 +117,14 @@ fun WallpaperDetailsScreen(
 
                 }
 
-                is WallpaperDetailsScreenUIAction.Apply -> Unit // todo
+                is WallpaperDetailsScreenUIAction.Apply -> {
+                    setWallpaperWithChooser(
+                        context = context,
+                        id = state.wallpaper.id,
+                        fileType = state.wallpaper.fileType
+                    )
+                }
+
                 else -> Unit
 
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,4 +42,5 @@
     <string name="apply_wallpaper_home_and_lock_screen"><![CDATA[Home & Lock Screen]]></string>
     <string name="something_went_wrong">Something went wrong.</string>
     <string name="not_implemented">Not implemented.</string>
+    <string name="set_as">Set as:</string>
 </resources>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-files-path
+        name="wallpapers"
+        path="Pictures/Stylepaper/" />
+</paths>


### PR DESCRIPTION
This commit introduces the ability for users to set a wallpaper from the wallpaper details screen.

Key changes include:
- Added a `FileProvider` to `AndroidManifest.xml` and defined file paths in `res/xml/file_paths.xml` to securely share wallpaper files.
- Created `setWallpaperWithChooser` utility function in `WallpaperManagerUtils.kt` to launch an intent that allows the user to choose how to set the wallpaper (e.g., home screen, lock screen, or both).
- Updated `WallpaperDetailsScreen.kt` to call `setWallpaperWithChooser` when the "Apply" action is triggered.
- Modified `FileUtils.kt` to expose `getWallpaperFile` for easier access to wallpaper files.
- Added a new string resource `set_as` for the chooser title.
- Updated `WallpaperDetailsScreenViewModel.kt` to correctly handle the `Apply` UI action.